### PR TITLE
Update IoTLoRaNode-strings.json

### DIFF
--- a/_locales/de/IoTLoRaNode-strings.json
+++ b/_locales/de/IoTLoRaNode-strings.json
@@ -22,6 +22,6 @@
   "SpreadingFactors.Nine|block": "Neun",
   "SpreadingFactors.Ten|block": "Zehn",
   "SpreadingFactors.Eleven|block": "Elf",
-  "SpreadingFactors.Twelve|block": "Zwölf"
+  "SpreadingFactors.Twelve|block": "Zwölf",
   "IotLoRaNode.SetRegion|block": "Setze LoRafrequenz auf: %regionVal"
 }


### PR DESCRIPTION
german locale didn´t work any more. Hope missing komma will fix it 